### PR TITLE
Add health pickups that spawn after enemy kills

### DIFF
--- a/godot/Health.tscn
+++ b/godot/Health.tscn
@@ -1,0 +1,17 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Texture2D" uid="uid://bvnxeyxhfo466" path="res://icon.png" id="1"]
+
+[sub_resource type="CircleShape2D" id="2"]
+
+[node name="Health" type="Health"]
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+modulate = Color(0, 1, 0, 1)
+scale = Vector2(0.5, 0.5)
+texture = ExtResource("1")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("2")
+
+[connection signal="body_entered" from="." to="." method="on_body_entered"]

--- a/src/health.rs
+++ b/src/health.rs
@@ -1,0 +1,56 @@
+use crate::player;
+use godot::classes::{Area2D, CollisionShape2D, IArea2D, Node2D, Sprite2D};
+use godot::prelude::*;
+
+#[derive(GodotClass)]
+#[class(base=Area2D)]
+pub struct Health {
+    heal_amount: i64,
+    base: Base<Area2D>,
+}
+
+#[godot_api]
+impl Health {
+    #[signal]
+    pub fn collected(amount: i64);
+
+    pub fn set_heal_amount(&mut self, amount: i64) {
+        self.heal_amount = amount;
+        let scale = if amount > 1 {
+            Vector2::new(1.0, 1.0)
+        } else {
+            Vector2::new(0.5, 0.5)
+        };
+        let mut sprite = self.base().get_node_as::<Sprite2D>("Sprite2D");
+        sprite.set_scale(scale);
+        let mut shape = self
+            .base()
+            .get_node_as::<CollisionShape2D>("CollisionShape2D");
+        shape.set_scale(scale);
+    }
+
+    #[func]
+    fn on_body_entered(&mut self, body: Gd<Node2D>) {
+        if body.try_cast::<player::Player>().is_ok() {
+            let amount = self.heal_amount;
+            self.signals().collected().emit(amount);
+            self.base_mut().queue_free();
+        }
+    }
+}
+
+#[godot_api]
+impl IArea2D for Health {
+    fn init(base: Base<Area2D>) -> Self {
+        Self {
+            heal_amount: 1,
+            base,
+        }
+    }
+
+    fn ready(&mut self) {
+        self.signals()
+            .body_entered()
+            .connect_self(Self::on_body_entered);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 use godot::prelude::*;
 
 mod fireball;
+mod health;
 mod hud;
 mod main_scene;
 mod mob;

--- a/src/player.rs
+++ b/src/player.rs
@@ -108,6 +108,10 @@ impl Player {
             .get_node_as::<AnimatedSprite2D>("AnimatedSprite2D");
         sprite.set_modulate(Color::from_rgba(1.0, 1.0, 1.0, 1.0));
     }
+
+    pub fn get_screen_size(&self) -> Vector2 {
+        self.screen_size
+    }
 }
 
 #[godot_api]


### PR DESCRIPTION
## Summary
- add `Health` area pickup that heals the player
- spawn health after random number of enemy kills, with chance for larger heal
- expose player screen size for placement

## Testing
- `cargo fmt`
- `cargo clippy --all-targets`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68956d5fd7e8832795990d1001061be4